### PR TITLE
Fix hashing of date expressions

### DIFF
--- a/src/Atis.SqlExpressionEngine/SqlExpressionHashGenerator.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressionHashGenerator.cs
@@ -111,7 +111,6 @@ namespace Atis.SqlExpressionEngine
         protected internal override SqlExpression VisitSqlDateAdd(SqlDateAddExpression node)
         {
             this.hashCode.Add(node.DatePart);
-            this.hashCode.Add(node.Interval);
             return base.VisitSqlDateAdd(node);
         }
 
@@ -124,8 +123,6 @@ namespace Atis.SqlExpressionEngine
         protected internal override SqlExpression VisitSqlDateSubtract(SqlDateSubtractExpression node)
         {
             this.hashCode.Add(node.DatePart);
-            this.hashCode.Add(node.StartDate);
-            this.hashCode.Add(node.EndDate);
             return base.VisitSqlDateSubtract(node);
         }
 


### PR DESCRIPTION
## Summary
- improve structural hashing for date arithmetic nodes

## Testing
- `dotnet test --no-build -c Release` *(fails: `dotnet` not found)*