### PR TITLE
Fix CastQueryMethodExpressionConverterFactory typo

### DIFF
--- a/src/Atis.SqlExpressionEngine/ExpressionConverters/CastQueryMethodExpressionConverterFactory.cs
+++ b/src/Atis.SqlExpressionEngine/ExpressionConverters/CastQueryMethodExpressionConverterFactory.cs
@@ -9,9 +9,9 @@ using System.Text;
 
 namespace Atis.SqlExpressionEngine.ExpressionConverters
 {
-    public class CastQueryMethoExpressionConverterFactory : QueryMethodExpressionConverterFactoryBase
+    public class CastQueryMethodExpressionConverterFactory : QueryMethodExpressionConverterFactoryBase
     {
-        public CastQueryMethoExpressionConverterFactory(IConversionContext context) : base(context)
+        public CastQueryMethodExpressionConverterFactory(IConversionContext context) : base(context)
         {
         }
 

--- a/src/Atis.SqlExpressionEngine/LinqToSqlExpressionConverterProvider.cs
+++ b/src/Atis.SqlExpressionEngine/LinqToSqlExpressionConverterProvider.cs
@@ -76,7 +76,7 @@ namespace Atis.SqlExpressionEngine
                 new DateFunctionsConverterFactory(context), 
                 new ToStringConverterFactory(context),
                 new GetValueOrDefaultConverterFactory(context),
-                new CastQueryMethoExpressionConverterFactory(context),
+                new CastQueryMethodExpressionConverterFactory(context),
             };
             this.Factories.AddRange(defaultConverters);
         }


### PR DESCRIPTION
## Summary
- fix typo in `CastQueryMethodExpressionConverterFactory`
- rename file to match class name
- update provider to use corrected factory name

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*