### PR TITLE
Use IReadOnlyList for converter stack

### DIFF
--- a/src/Atis.Expressions/ExpressionConverterBase.cs
+++ b/src/Atis.Expressions/ExpressionConverterBase.cs
@@ -19,7 +19,9 @@ namespace Atis.Expressions
         /// </summary>
         /// <param name="expression">The source expression that will be converted.</param>
         /// <param name="converterStack">The stack of converters representing the parent chain for context-aware conversion.</param>
-        protected ExpressionConverterBase(TSourceExpression expression, ExpressionConverterBase<TSourceExpression, TDestinationExpression>[] converterStack)
+        protected ExpressionConverterBase(
+            TSourceExpression expression,
+            IReadOnlyList<ExpressionConverterBase<TSourceExpression, TDestinationExpression>> converterStack)
         {
             this.Expression = expression;
             this.ConverterStack = converterStack;
@@ -28,7 +30,7 @@ namespace Atis.Expressions
         /// <summary>
         /// Gets the stack of converters representing the context hierarchy of the current conversion.
         /// </summary>
-        public virtual ExpressionConverterBase<TSourceExpression, TDestinationExpression>[] ConverterStack { get; }
+        public virtual IReadOnlyList<ExpressionConverterBase<TSourceExpression, TDestinationExpression>> ConverterStack { get; }
 
         /// <summary>
         /// Gets the source expression that is currently being converted.


### PR DESCRIPTION
## Summary
- switch converter stack type in `ExpressionConverterBase` to `IReadOnlyList`

## Testing
- `dotnet test --verbosity minimal` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*