### PR TITLE
Update string function arguments

### DIFF
--- a/src/Atis.SqlExpressionEngine.UnitTest/SqlExpressionTranslator.cs
+++ b/src/Atis.SqlExpressionEngine.UnitTest/SqlExpressionTranslator.cs
@@ -453,7 +453,7 @@ namespace Atis.SqlExpressionEngine.UnitTest
         private string TranslateSqlStringFunctionExpression(SqlStringFunctionExpression sqlStringFunctionExpression)
         {
             string arguments = string.Empty;
-            if (sqlStringFunctionExpression.Arguments?.Length > 0)
+            if (sqlStringFunctionExpression.Arguments?.Count > 0)
                 arguments = $", {string.Join(", ", sqlStringFunctionExpression.Arguments.Select(this.Translate))}";
             return $"{sqlStringFunctionExpression.StringFunction}({this.Translate(sqlStringFunctionExpression.StringExpression)}{arguments})";
         }

--- a/src/Atis.SqlExpressionEngine/Abstractions/ISqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Abstractions/ISqlExpressionFactory.cs
@@ -16,7 +16,7 @@ namespace Atis.SqlExpressionEngine.Abstractions
         SqlSelectExpression CreateSelectQueryFromStandaloneSelect(SqlStandaloneSelectExpression standaloneSelect);
         SqlSelectExpression CreateSelectQuery(SqlExpression queryShape);
         SqlAliasExpression CreateAlias(string alias);
-        SqlStringFunctionExpression CreateStringFunction(SqlStringFunction stringFunction, SqlExpression stringExpression, SqlExpression[] arguments);
+        SqlStringFunctionExpression CreateStringFunction(SqlStringFunction stringFunction, SqlExpression stringExpression, IReadOnlyList<SqlExpression> arguments);
         SqlFunctionCallExpression CreateFunctionCall(string functionName, SqlExpression[] arguments);
         SqlConditionalExpression CreateCondition(SqlExpression test, SqlExpression ifTrue, SqlExpression ifFalse);
         SqlDefaultIfEmptyExpression CreateDefaultIfEmpty(SqlDerivedTableExpression derivedTable);

--- a/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
@@ -154,7 +154,7 @@ namespace Atis.SqlExpressionEngine.Services
             return new SqlLiteralExpression(value);
         }
 
-        public SqlStringFunctionExpression CreateStringFunction(SqlStringFunction stringFunction, SqlExpression stringExpression, SqlExpression[] arguments)
+        public SqlStringFunctionExpression CreateStringFunction(SqlStringFunction stringFunction, SqlExpression stringExpression, IReadOnlyList<SqlExpression> arguments)
         {
             return new SqlStringFunctionExpression(stringFunction, stringExpression, arguments);
         }

--- a/src/Atis.SqlExpressionEngine/SqlExpressionVisitor.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressionVisitor.cs
@@ -134,7 +134,7 @@ namespace Atis.SqlExpressionEngine
                     newArguments.Add(this.Visit(argument));
                 }
             }
-            return node.Update(stringExpression, newArguments.ToArray());
+            return node.Update(stringExpression, newArguments);
         }
 
         protected virtual internal SqlExpression VisitSqlFunctionCall(SqlFunctionCallExpression node)

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlStringFunctionExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlStringFunctionExpression.cs
@@ -9,10 +9,10 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
     {
         public override SqlExpressionType NodeType => SqlExpressionType.StringFunction;
         public SqlExpression StringExpression { get; }
-        public SqlExpression[] Arguments { get; }
+        public IReadOnlyList<SqlExpression> Arguments { get; }
         public SqlStringFunction StringFunction { get; }
 
-        public SqlStringFunctionExpression(SqlStringFunction stringFunction, SqlExpression stringExpression, SqlExpression[] arguments)
+        public SqlStringFunctionExpression(SqlStringFunction stringFunction, SqlExpression stringExpression, IReadOnlyList<SqlExpression> arguments)
         {
             this.StringFunction = stringFunction;
             this.StringExpression = stringExpression ?? throw new ArgumentNullException(nameof(stringExpression));
@@ -24,7 +24,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
             return sqlExpressionVisitor.VisitSqlStringFunction(this);
         }
 
-        public SqlStringFunctionExpression Update(SqlExpression stringExpression, SqlExpression[] arguments)
+        public SqlStringFunctionExpression Update(SqlExpression stringExpression, IReadOnlyList<SqlExpression> arguments)
         {
             if (stringExpression == this.StringExpression && ArgumentsSame(arguments))
             {
@@ -33,12 +33,12 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
             return new SqlStringFunctionExpression(this.StringFunction, stringExpression, arguments);
         }
 
-        private bool ArgumentsSame(SqlExpression[] arguments)
+        private bool ArgumentsSame(IReadOnlyList<SqlExpression> arguments)
         {
-            if (this.Arguments?.Length != arguments?.Length)
+            if (this.Arguments?.Count != arguments?.Count)
                 return false;
 
-            for (int i = 0; i < arguments.Length; i++)
+            for (int i = 0; i < arguments.Count; i++)
             {
                 if (arguments[i] != this.Arguments[i])
                     return false;


### PR DESCRIPTION
## Summary
- make `SqlStringFunctionExpression.Arguments` an `IReadOnlyList`
- update constructor and logic to use list semantics
- adjust factories, visitor, and translator for the new API

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*