### PR TITLE
Switch TableColumns to IReadOnlyList

### DIFF
--- a/src/Atis.SqlExpressionEngine.UnitTest/Services/Model.cs
+++ b/src/Atis.SqlExpressionEngine.UnitTest/Services/Model.cs
@@ -2,6 +2,7 @@
 using Atis.SqlExpressionEngine.SqlExpressions;
 using Atis.SqlExpressionEngine.UnitTest.Metadata;
 using System.Reflection;
+using System.Collections.Generic;
 
 namespace Atis.SqlExpressionEngine.UnitTest.Services
 {
@@ -23,7 +24,7 @@ namespace Atis.SqlExpressionEngine.UnitTest.Services
                             .ToArray();
         }
 
-        public override TableColumn[] GetTableColumns(Type type)
+        public override IReadOnlyList<TableColumn> GetTableColumns(Type type)
         {
             return this.GetColumnMembers(type)
                             .Select(x => new TableColumn(x.Name, x.Name)).ToArray();

--- a/src/Atis.SqlExpressionEngine/Abstractions/IModel.cs
+++ b/src/Atis.SqlExpressionEngine/Abstractions/IModel.cs
@@ -28,12 +28,12 @@ namespace Atis.SqlExpressionEngine.Abstractions
 
         /// <summary>
         ///     <para>
-        ///         Gets an array of table columns corresponding to the specified type.
+        ///         Gets a list of table columns corresponding to the specified type.
         ///     </para>
         /// </summary>
         /// <param name="type">The type of the model.</param>
-        /// <returns>An array of <see cref="TableColumn"/> objects.</returns>
-        TableColumn[] GetTableColumns(Type type);
+        /// <returns>A list of <see cref="TableColumn"/> objects.</returns>
+        IReadOnlyList<TableColumn> GetTableColumns(Type type);
 
         /// <summary>
         ///     <para>

--- a/src/Atis.SqlExpressionEngine/Abstractions/ISqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Abstractions/ISqlExpressionFactory.cs
@@ -9,7 +9,7 @@ namespace Atis.SqlExpressionEngine.Abstractions
     {
         SqlBinaryExpression CreateBinary(SqlExpression left, SqlExpression right, SqlExpressionType sqlExpressionType);
         SqlLiteralExpression CreateLiteral(object value);
-        SqlTableExpression CreateTable(string tableName, TableColumn[] tableColumns);
+        SqlTableExpression CreateTable(string tableName, IReadOnlyList<TableColumn> tableColumns);
         SqlDerivedTableExpression ConvertSelectQueryToDeriveTable(SqlSelectExpression selectQuery);
         SqlDerivedTableExpression ConvertSelectQueryToUnwrappableDeriveTable(SqlSelectExpression selectQuery);
         SqlDerivedTableExpression ConvertSelectQueryToDataManipulationDerivedTable(SqlSelectExpression selectQuery);

--- a/src/Atis.SqlExpressionEngine/Services/Model.cs
+++ b/src/Atis.SqlExpressionEngine/Services/Model.cs
@@ -36,7 +36,7 @@ namespace Atis.SqlExpressionEngine.Services
         }
 
         /// <inheritdoc />
-        public virtual TableColumn[] GetTableColumns(Type type)
+        public virtual IReadOnlyList<TableColumn> GetTableColumns(Type type)
         {
             return type.GetProperties().Select(x => new TableColumn(x.Name, x.Name)).ToArray();
         }

--- a/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
@@ -159,7 +159,7 @@ namespace Atis.SqlExpressionEngine.Services
             return new SqlStringFunctionExpression(stringFunction, stringExpression, arguments);
         }
 
-        public SqlTableExpression CreateTable(string tableName, TableColumn[] tableColumns)
+        public SqlTableExpression CreateTable(string tableName, IReadOnlyList<TableColumn> tableColumns)
         {
             return new SqlTableExpression(tableName, tableColumns);
         }

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlTableExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlTableExpression.cs
@@ -17,7 +17,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
         /// <param name="tableName"></param>
         /// <param name="tableColumns"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SqlTableExpression(string tableName, TableColumn[] tableColumns)
+        public SqlTableExpression(string tableName, IReadOnlyList<TableColumn> tableColumns)
         {
             this.TableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
             this.TableColumns = tableColumns ?? throw new ArgumentNullException(nameof(tableColumns));
@@ -37,7 +37,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
         /// <summary>
         /// 
         /// </summary>
-        public TableColumn[] TableColumns { get; }
+        public IReadOnlyList<TableColumn> TableColumns { get; }
 
         /// <inheritdoc />
         public override SqlDataSourceQueryShapeExpression CreateQueryShape(Guid dataSourceAlias)


### PR DESCRIPTION
## Summary
- update `SqlTableExpression.TableColumns` to `IReadOnlyList<TableColumn>`
- update constructor and factory methods for `SqlTableExpression`
- update interfaces and implementations that expose table columns

## Testing
- `dotnet build` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*
- `dotnet test` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*