### PR TITLE
Switch OrderByColumns to IReadOnlyList

### DIFF
--- a/src/Atis.SqlExpressionEngine/Internal/JoinableQueryBuilder.cs
+++ b/src/Atis.SqlExpressionEngine/Internal/JoinableQueryBuilder.cs
@@ -69,7 +69,7 @@ namespace Atis.SqlExpressionEngine.Internal
                    //this.derivedTable.CteDataSources.Length == 0 &&
                     !(this.derivedTable.HavingClause?.FilterConditions.Length > 0) &&
                     this.derivedTable.GroupByClause.Length == 0 &&
-                    !(this.derivedTable.OrderByClause?.OrderByColumns.Length > 0) &&
+                    !(this.derivedTable.OrderByClause?.OrderByColumns.Count > 0) &&
                     this.derivedTable.Top == null &&
                     this.derivedTable.IsDistinct == false &&
                     this.derivedTable.RowOffset == null &&

--- a/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
@@ -304,7 +304,7 @@ namespace Atis.SqlExpressionEngine.Services
                     derivedTable.Joins.All(x => x.IsNavigationJoin)) &&
                     !(derivedTable.HavingClause?.FilterConditions.Length > 0) &&
                     derivedTable.GroupByClause.Length == 0 &&
-                    !(derivedTable.OrderByClause?.OrderByColumns.Length > 0) &&
+                    !(derivedTable.OrderByClause?.OrderByColumns.Count > 0) &&
                     derivedTable.Top == null &&
                     derivedTable.IsDistinct == false &&
                     derivedTable.RowOffset == null &&

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlDerivedTableExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlDerivedTableExpression.cs
@@ -57,7 +57,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
                                 this.CteDataSources.Length == 0 &&
                                 !(this.HavingClause?.FilterConditions.Length > 0) &&
                                 this.GroupByClause.Length == 0 &&
-                                !(this.OrderByClause?.OrderByColumns.Length > 0) &&
+                                !(this.OrderByClause?.OrderByColumns.Count > 0) &&
                                 this.Top == null &&
                                 this.IsDistinct == false &&
                                 this.RowOffset == null &&

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlOrderByClauseExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlOrderByClauseExpression.cs
@@ -7,16 +7,16 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
 {
     public class SqlOrderByClauseExpression : SqlExpression
     {
-        public SqlOrderByClauseExpression(OrderByColumn[] orderByColumns)
+        public SqlOrderByClauseExpression(IReadOnlyList<OrderByColumn> orderByColumns)
         {
-            if (!(orderByColumns?.Length > 0))
+            if (!(orderByColumns?.Count > 0))
                 throw new ArgumentNullException(nameof(orderByColumns), "Order by columns cannot be null or empty.");
             this.OrderByColumns = orderByColumns;
         }
 
         /// <inheritdoc />
         public override SqlExpressionType NodeType => SqlExpressionType.OrderByClause;
-        public OrderByColumn[] OrderByColumns { get; }
+        public IReadOnlyList<OrderByColumn> OrderByColumns { get; }
 
         /// <inheritdoc />
         protected internal override SqlExpression Accept(SqlExpressionVisitor visitor)
@@ -24,7 +24,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
             return visitor.VisitSqlOrderByClause(this);
         }
 
-        public SqlOrderByClauseExpression Update(OrderByColumn[] orderByColumns)
+        public SqlOrderByClauseExpression Update(IReadOnlyList<OrderByColumn> orderByColumns)
         {
             if (this.OrderByColumns.AllEqual(orderByColumns))
                 return this;


### PR DESCRIPTION
## Summary
- make `SqlOrderByClauseExpression.OrderByColumns` an `IReadOnlyList`
- adjust constructor and `Update` method signatures
- update references checking collection length

## Testing
- `dotnet test --no-build`