### PR TITLE
Refactor filter clause list type

### DIFF
--- a/src/Atis.SqlExpressionEngine.UnitTest/SqlExpressionTranslator.cs
+++ b/src/Atis.SqlExpressionEngine.UnitTest/SqlExpressionTranslator.cs
@@ -192,10 +192,10 @@ namespace Atis.SqlExpressionEngine.UnitTest
                 &&
                 node.QuerySource is SqlDerivedTableExpression derivedTable)
             {
-                if (!(derivedTable.WhereClause?.FilterConditions.Length > 0)    // must have filter condition
+                if (!(derivedTable.WhereClause?.FilterConditions.Count > 0)    // must have filter condition
                     ||
                     derivedTable.GroupByClause?.Count > 0 ||                   // must not have grouping
-                    derivedTable.HavingClause?.FilterConditions.Length > 0      // or having
+                    derivedTable.HavingClause?.FilterConditions.Count > 0      // or having
                     ||
                     !(derivedTable.QueryShape is SqlQueryShapeExpression)       // either shape is not Query Shape
                     ||                                                          // or it is query shape but it's a scalar
@@ -316,14 +316,14 @@ namespace Atis.SqlExpressionEngine.UnitTest
 
         private string JoinPredicate(SqlFilterClauseExpression filterClause, string method)
         {
-            if (filterClause is null || filterClause.FilterConditions.Length == 0)
+            if (filterClause is null || filterClause.FilterConditions.Count == 0)
                 return string.Empty;
 
             var predicateString = new StringBuilder();
 
-            for (var i = 0; i < filterClause.FilterConditions.Length; i++)
+            for (var i = 0; i < filterClause.FilterConditions.Count; i++)
             {
-                var isLastCondition = i == filterClause.FilterConditions.Length - 1;
+                var isLastCondition = i == filterClause.FilterConditions.Count - 1;
                 var condition = filterClause.FilterConditions[i];
 
                 var translated = Indent(this.TranslateLogicalExpression(condition.Predicate));

--- a/src/Atis.SqlExpressionEngine/Internal/JoinableQueryBuilder.cs
+++ b/src/Atis.SqlExpressionEngine/Internal/JoinableQueryBuilder.cs
@@ -67,7 +67,7 @@ namespace Atis.SqlExpressionEngine.Internal
                    //this.derivedTable.AllDataSources.Count == 1 &&
                    //this.derivedTable.Joins.Length == 0 &&
                    //this.derivedTable.CteDataSources.Length == 0 &&
-                    !(this.derivedTable.HavingClause?.FilterConditions.Length > 0) &&
+                    !(this.derivedTable.HavingClause?.FilterConditions.Count > 0) &&
                     this.derivedTable.GroupByClause.Count == 0 &&
                     !(this.derivedTable.OrderByClause?.OrderByColumns.Count > 0) &&
                     this.derivedTable.Top == null &&
@@ -75,7 +75,7 @@ namespace Atis.SqlExpressionEngine.Internal
                     this.derivedTable.RowOffset == null &&
                     this.derivedTable.RowsPerPage == null;
                     //&&
-                    //this.derivedTable.WhereClause?.FilterConditions.Length > 0;
+                    //this.derivedTable.WhereClause?.FilterConditions.Count > 0;
         }
 
         public bool TryBuild(out JoinableQueryBuilderResult result)

--- a/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
+++ b/src/Atis.SqlExpressionEngine/Services/SqlExpressionFactory.cs
@@ -302,7 +302,7 @@ namespace Atis.SqlExpressionEngine.Services
                     (derivedTable.Joins.Count == 0 ||     // either there are no joins
                                                            // or all the joins are navigation joins
                     derivedTable.Joins.All(x => x.IsNavigationJoin)) &&
-                    !(derivedTable.HavingClause?.FilterConditions.Length > 0) &&
+                    !(derivedTable.HavingClause?.FilterConditions.Count > 0) &&
                     derivedTable.GroupByClause.Count == 0 &&
                     !(derivedTable.OrderByClause?.OrderByColumns.Count > 0) &&
                     derivedTable.Top == null &&

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlDerivedTableExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlDerivedTableExpression.cs
@@ -55,14 +55,14 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
                                     this.FromSource.QuerySource is SqlCteReferenceExpression) &&
                                 this.Joins.Count == 0 &&
                                 this.CteDataSources.Count == 0 &&
-                                !(this.HavingClause?.FilterConditions.Length > 0) &&
+                                !(this.HavingClause?.FilterConditions.Count > 0) &&
                                 this.GroupByClause.Count == 0 &&
                                 !(this.OrderByClause?.OrderByColumns.Count > 0) &&
                                 this.Top == null &&
                                 this.IsDistinct == false &&
                                 this.RowOffset == null &&
                                 this.RowsPerPage == null &&
-                               !(this.WhereClause?.FilterConditions?.Length > 0);
+                               !(this.WhereClause?.FilterConditions?.Count > 0);
 
             this.AllDataSources = ((IEnumerable<SqlAliasedDataSourceExpression>)new[] { this.FromSource })
                                         .Concat(this.Joins)

--- a/src/Atis.SqlExpressionEngine/SqlExpressions/SqlFilterClauseExpression.cs
+++ b/src/Atis.SqlExpressionEngine/SqlExpressions/SqlFilterClauseExpression.cs
@@ -16,9 +16,9 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
                 ? nodeType
                 : throw new InvalidOperationException($"SqlExpressionType '{nodeType}' is not a valid Filter Clause.");
 
-        public SqlFilterClauseExpression(FilterCondition[] filterConditions, SqlExpressionType nodeType)
+        public SqlFilterClauseExpression(IReadOnlyList<FilterCondition> filterConditions, SqlExpressionType nodeType)
         {
-            if (!(filterConditions?.Length > 0))
+            if (!(filterConditions?.Count > 0))
                 throw new ArgumentNullException(nameof(filterConditions), "Filter conditions cannot be null or empty.");
             this.FilterConditions = filterConditions;
             this.NodeType = ValidateNodeType(nodeType);
@@ -26,7 +26,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
 
         /// <inheritdoc />
         public override SqlExpressionType NodeType { get; }
-        public FilterCondition[] FilterConditions { get; }
+        public IReadOnlyList<FilterCondition> FilterConditions { get; }
 
         /// <inheritdoc />
         protected internal override SqlExpression Accept(SqlExpressionVisitor visitor)
@@ -34,7 +34,7 @@ namespace Atis.SqlExpressionEngine.SqlExpressions
             return visitor.VisitFilterClause(this);
         }
 
-        public SqlFilterClauseExpression Update(FilterCondition[] filterConditions)
+        public SqlFilterClauseExpression Update(IReadOnlyList<FilterCondition> filterConditions)
         {
             if (this.FilterConditions.AllEqual(filterConditions))
                 return this;

--- a/src/Atis.SqlExpressionEngine/Visitors/JoinPredicateExtractor.cs
+++ b/src/Atis.SqlExpressionEngine/Visitors/JoinPredicateExtractor.cs
@@ -331,7 +331,7 @@ namespace Atis.SqlExpressionEngine.Visitors
                 }
                 newFilterConditions.Add(filter);
             }
-            if (newFilterConditions.Count != visited.FilterConditions.Length)
+            if (newFilterConditions.Count != visited.FilterConditions.Count)
             {
                 if (newFilterConditions.Count == 0)
                 {


### PR DESCRIPTION
## Summary
- use `IReadOnlyList<FilterCondition>` for `SqlFilterClauseExpression.FilterConditions`
- update query builder and services to use `.Count`
- adjust translator and extractor to new list type
- update tests

## Testing
- `dotnet test --no-build`