### PR TITLE
Update NavigationLinkAttribute to use IReadOnlyList

### DIFF
--- a/src/Atis.SqlExpressionEngine.UnitTest/Metadata/NavigationLinkAttribute.cs
+++ b/src/Atis.SqlExpressionEngine.UnitTest/Metadata/NavigationLinkAttribute.cs
@@ -3,15 +3,15 @@
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class NavigationLinkAttribute : Attribute
     {
-        public string[] ParentKeys { get; }
-        public string[] ForeignKeysInChild { get; }
+        public IReadOnlyList<string> ParentKeys { get; }
+        public IReadOnlyList<string> ForeignKeysInChild { get; }
         public NavigationType NavigationType { get; }
 
         public NavigationLinkAttribute(NavigationType navigationType, string parentKey, string foreignKeyInChild)
         {
             this.NavigationType = navigationType;
-            this.ParentKeys = new string[] { parentKey };
-            this.ForeignKeysInChild = new string[] { foreignKeyInChild };
+            this.ParentKeys = new[] { parentKey };
+            this.ForeignKeysInChild = new[] { foreignKeyInChild };
         }
 
         public NavigationLinkAttribute(NavigationType navigationType, string[] parentKeys, string[] foreignKeysInChild)

--- a/src/Atis.SqlExpressionEngine.UnitTest/Preprocessors/NavigateToOnePreprocessor.cs
+++ b/src/Atis.SqlExpressionEngine.UnitTest/Preprocessors/NavigateToOnePreprocessor.cs
@@ -194,10 +194,10 @@ namespace Atis.SqlExpressionEngine.UnitTest.Preprocessors
 
             var navigationType = relationAttribute.NavigationType;
 
-            if (!(relationAttribute.ParentKeys?.Length >= 1 && relationAttribute.ForeignKeysInChild?.Length >= 1))
+            if (!(relationAttribute.ParentKeys?.Count >= 1 && relationAttribute.ForeignKeysInChild?.Count >= 1))
                 throw new InvalidOperationException("ParentKeys or ForeignKeysInChild is not set.");
 
-            if (relationAttribute.ParentKeys.Length != relationAttribute.ForeignKeysInChild.Length)
+            if (relationAttribute.ParentKeys.Count != relationAttribute.ForeignKeysInChild.Count)
                 throw new InvalidOperationException($"ParentKeys and ForeignKeysInChild must have the same number of elements.");
 
             Type childModelType = modelType ?? throw new InvalidOperationException($"ReflectedType property is null for member '{member.Name}'.");


### PR DESCRIPTION
## Summary
- use `IReadOnlyList<string>` for `ParentKeys` and `ForeignKeysInChild`
- update constructors to fill these readonly lists
- adapt checks in `NavigateToOnePreprocessor`

## Testing
- `dotnet test --no-build`
- `dotnet build --no-restore`